### PR TITLE
Bqn implementation

### DIFF
--- a/fpaq0.bqn
+++ b/fpaq0.bqn
@@ -51,4 +51,4 @@ in‿out:
     Fclose∘⥊¨ in_stream‿out_stream
 }
 
-EncodeFile "book1.bz3"‿"/dev/null"
+EncodeFile •args

--- a/fpaq0.bqn
+++ b/fpaq0.bqn
@@ -1,0 +1,53 @@
+#!/bin/env BQN
+
+fopen  ← "/usr/lib/libc.so.6" •FFI "u64"‿"fopen"‿"*u8"‿"*u8"
+fclose ← "/usr/lib/libc.so.6" •FFI "i32"‿"fclose"‿"u64"
+fgetc  ← "/usr/lib/libc.so.6" •FFI "i32"‿"fgetc"‿"u64"
+fputc  ← "/usr/lib/libc.so.6" •FFI "i32"‿"fputc"‿"i32"‿"u64"
+fflush ← "/usr/lib/libc.so.6" •FFI "i32"‿"fflush"‿"u64"
+
+High  ← ⌊∘÷⟜16777216
+Trunc ← 4294967296⊸|
+Xor   ← Trunc∘⊑ 32•bit._xor○{⥊𝕩-(𝕩≥2147483648)×4294967296}
+
+ctx ← 1
+ct ← 256‿2⥊0
+Predict ← {
+	ct (1⊸+ ⌾ (ctx‿𝕩⊸⊑))↩
+	ct ⌊∘÷⟜2 ⌾ (ctx⊸⊏) ⍟ (65534<ctx‿𝕩⊑ct)↩
+	ctx 1⍟(256≤ctx +↩ ctx+𝕩) ↩
+	(4096×1+ctx‿1⊑ct)⌊∘÷2+´ctx⊏ct
+}
+
+New ← {
+	out ← 𝕩
+	{
+		x ← 0
+		x1 ← 0
+		x2 ← 4294967295
+		p ← 2048
+		Flush ⇐ {𝕩: Fputc (High x1)‿out ⋄@}
+		Rescale ← {𝕩:x1 ↩ Trunc x1×256 ⋄ x2 ↩ Trunc 255+256×x2 ⋄@}
+		EncodeBit ⇐ {
+			xmid ← Trunc x1 + (p×range⌊∘÷4096) + (p×4096|range←x2-x1) ⌊∘÷ 4096
+			p ↩ Predict 𝕩
+			𝕩◶{𝕩:x1 ↩ xmid+1}‿{𝕩:x2 ↩ xmid} @
+			Rescale∘Flush •_while_ {𝕩:0≡High x1 Xor x2} @
+		}
+	}
+}
+
+EncodeFile ← {
+in‿out:
+	size ← •file.Size in
+	in_stream ← Fopen 0∾¨˜ @-˜  in‿"r"
+	out_stream ← Fopen 0∾¨˜ @-˜ out‿"w"
+	{Fputc 𝕩‿out_stream}¨ ⌽⥊32‿8 •bit._cast ⥊size
+	ac ← New out_stream
+	c ← 0
+	{𝕩:ac.EncodeBit¨ ⌽8‿1•bit._cast⥊{𝕩-(𝕩≥128)×256}c} •_while_ {𝕩:¯1≢c↩Fgetc ⥊in_stream} @
+	ac.Flush @
+	Fclose∘⥊¨ in_stream‿out_stream
+}
+
+EncodeFile •args

--- a/fpaq0.bqn
+++ b/fpaq0.bqn
@@ -1,53 +1,54 @@
 #!/bin/env BQN
 
-fopen  ← "/usr/lib/libc.so.6" •FFI "u64"‿"fopen"‿"*u8"‿"*u8"
-fclose ← "/usr/lib/libc.so.6" •FFI "i32"‿"fclose"‿"u64"
-fgetc  ← "/usr/lib/libc.so.6" •FFI "i32"‿"fgetc"‿"u64"
-fputc  ← "/usr/lib/libc.so.6" •FFI "i32"‿"fputc"‿"i32"‿"u64"
-fflush ← "/usr/lib/libc.so.6" •FFI "i32"‿"fflush"‿"u64"
-
-High  ← ⌊∘÷⟜16777216
-Trunc ← 4294967296⊸|
-Xor   ← Trunc∘⊑ 32•bit._xor○{⥊𝕩-(𝕩≥2147483648)×4294967296}
+fopen  ← "/usr/lib/libc.so.6" •FFI "*"‿"fopen"‿"*u8"‿"*u8"
+fclose ← "/usr/lib/libc.so.6" •FFI "i32"‿"fclose"‿"*"
+fgetc  ← "/usr/lib/libc.so.6" •FFI "i32"‿"fgetc"‿"*"
+fputc  ← "/usr/lib/libc.so.6" •FFI "i32"‿"fputc"‿"i32"‿"*"
+fflush ← "/usr/lib/libc.so.6" •FFI "i32"‿"fflush"‿"*"
 
 ctx ← 1
 ct ← 256‿2⥊0
-Predict ← {
-	ct (1⊸+ ⌾ (ctx‿𝕩⊸⊑))↩
-	ct ⌊∘÷⟜2 ⌾ (ctx⊸⊏) ⍟ (65534<ctx‿𝕩⊑ct)↩
-	ctx 1⍟(256≤ctx +↩ ctx+𝕩) ↩
-	(4096×1+ctx‿1⊑ct)⌊∘÷2+´ctx⊏ct
-}
 
 New ← {
-	out ← 𝕩
-	{
-		x ← 0
-		x1 ← 0
-		x2 ← 4294967295
-		p ← 2048
-		Flush ⇐ {𝕩: Fputc (High x1)‿out ⋄@}
-		Rescale ← {𝕩:x1 ↩ Trunc x1×256 ⋄ x2 ↩ Trunc 255+256×x2 ⋄@}
-		EncodeBit ⇐ {
-			xmid ← Trunc x1 + (p×range⌊∘÷4096) + (p×4096|range←x2-x1) ⌊∘÷ 4096
-			p ↩ Predict 𝕩
-			𝕩◶{𝕩:x1 ↩ xmid+1}‿{𝕩:x2 ↩ xmid} @
-			Rescale∘Flush •_while_ {𝕩:0≡High x1 Xor x2} @
-		}
-	}
+    out ← 𝕩
+    {
+        x ← x1 ← 0
+        x2 ← 4294967295
+        p ← 2048
+        Flush ⇐ {𝕩: 
+            Fputc (⌊x1÷16777216)‿out 
+            @
+        }
+        EncodeBit ⇐ {
+            xmid ← 4294967296|x1+(p×⌊range÷4096)+⌊(p×4096|range←x2-x1)÷4096
+            ct (1⊸+ ⌾ (ctx‿𝕩⊸⊑))↩
+            ct ⌊∘÷⟜2 ⌾ (ctx⊸⊏) ⍟ (65534<ctx‿𝕩⊑ct)↩
+            ctx 1⍟(256≤ctx +↩ ctx+𝕩) ↩
+            p ↩ (4096×1+ctx‿1⊑ct)⌊∘÷2+´ctx⊏ct
+            𝕩◶{𝕩:x1 ↩ xmid+1}‿{𝕩:x2 ↩ xmid} @
+            {𝕩:
+                Fputc (⌊x1÷16777216)‿out 
+                x1 ↩ 4294967296|x1×256 
+                x2 ↩ 4294967296|255+x2×256 
+                @
+            } •_while_ {𝕩:
+                0≡⌊÷⟜16777216 4294967296|⊑ x1 32•bit._xor○(⥊-⟜(4294967296×≥⟜2147483648)) x2
+            } @
+        }
+    }
 }
 
 EncodeFile ← {
 in‿out:
-	size ← •file.Size in
-	in_stream ← Fopen 0∾¨˜ @-˜  in‿"r"
-	out_stream ← Fopen 0∾¨˜ @-˜ out‿"w"
-	{Fputc 𝕩‿out_stream}¨ ⌽⥊32‿8 •bit._cast ⥊size
-	ac ← New out_stream
-	c ← 0
-	{𝕩:ac.EncodeBit¨ ⌽8‿1•bit._cast⥊{𝕩-(𝕩≥128)×256}c} •_while_ {𝕩:¯1≢c↩Fgetc ⥊in_stream} @
-	ac.Flush @
-	Fclose∘⥊¨ in_stream‿out_stream
+    size ← •file.Size in
+    in_stream ← Fopen 0∾¨˜ @-˜in‿"r"
+    out_stream ← Fopen 0∾¨˜ @-˜out‿"w"
+    {Fputc 𝕩‿out_stream}¨ ⌽⥊32‿8•bit._cast ⥊-⟜(4294967296×≥⟜2147483648)size
+    ac ← New out_stream
+    c ← 0
+    {𝕩:ac.EncodeBit¨⌽8‿1•bit._cast⥊-⟜(256×≥⟜128)c} •_while_ {𝕩:¯1≢c↩Fgetc ⥊in_stream} @
+    ac.Flush @
+    Fclose∘⥊¨ in_stream‿out_stream
 }
 
-EncodeFile •args
+EncodeFile "book1.bz3"‿"/dev/null"


### PR DESCRIPTION
The implementation suffers greatly due to the signedness conversion before the bitwise XOR.
CBQN currently doesn't implement bitwise operation on unsigned types other than U1. That would definitely speed this up somewhat (and get rid of some magic constants).
Timing wise on my machine this runs about 25x slower than luajit, 38x slower than unoptimized GCC, 100x slower than GCC with -O2. I'm sure there's something that can be done to improve the timing, but I doubt any order of magnitude jumps are possible.